### PR TITLE
サイドバーへのグループの表示

### DIFF
--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -5,12 +5,8 @@
     = link_to (fa_icon "cog"), edit_user_registration_path, class: "sidebar-header__edit-account-btn"
 
   .sidebar-group-list
-    %a{href: "", class: "sidebar-group-list__group chat-group"}
-      %p.chat-group__name Group 1
-      %p.chat-group__message Morning.
-    %a{href: "", class: "sidebar-group-list__group chat-group"}
-      %p.chat-group__name Group 2
-      %p.chat-group__message Afternoon.
-    %a{href: "", class: "sidebar-group-list__group chat-group"}
-      %p.chat-group__name Group 3
-      %p.chat-group__message Evening.
+    - unless current_user.groups.empty?
+      - current_user.groups.each do |group|
+        = link_to "", class: "sidebar-group-list__group chat-group" do
+          %p.chat-group__name= group.name
+          %p.chat-group__message まだメッセージはありません。


### PR DESCRIPTION
# WHAT
サインイン中のユーザが所属するグループをサイドバーに表示する。

# WHY
アプリに必要な機能であるため。